### PR TITLE
ColorSwap material is now assigned in code and doesn't need to be set…

### DIFF
--- a/BingerNinja/Assets/Prefabs/ColorChanger/ColorChanger.prefab
+++ b/BingerNinja/Assets/Prefabs/ColorChanger/ColorChanger.prefab
@@ -43,6 +43,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 18ae702426f89bd4491da03d24a48364, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  m_swapMaterial: {fileID: 2100000, guid: c32d50fb846c662449889d803366ef5d, type: 2}
   m_colorOutGrey60: {r: 0.027901383, g: 0.31132078, b: 0.055962734, a: 1}
   m_colorOutGrey122: {r: 0, g: 0.5566038, b: 0.04337174, a: 1}
   m_colorOutGrey174: {r: 0.39048302, g: 0, b: 0.5188679, a: 1}

--- a/BingerNinja/Assets/Scripts/ColorChanger/ColorChanger_Jann.cs
+++ b/BingerNinja/Assets/Scripts/ColorChanger/ColorChanger_Jann.cs
@@ -5,6 +5,7 @@
 // Jann 29/10/20 - Proof of concept implementation
 // Jann 01/11/20 - Inspector UI, finalizing implementation
 // Jann 03/11/20 - Added TilemapRenderer and Image (UI) support
+// Jann 07/11/20 - Materials are now assigned in code and don't need to be set for everything in Unity
 
 using UnityEngine;
 using UnityEngine.Tilemaps;
@@ -16,6 +17,8 @@ public class ColorChanger_Jann : MonoBehaviour
     private const int Grey122 = 122;
     private const int Grey174 = 174;
 
+    public Material m_swapMaterial;
+    
     public Color m_colorOutGrey60 = new Color(0, 0, 0, 1);
     public Color m_colorOutGrey122 = new Color(0, 0, 0, 1);
     public Color m_colorOutGrey174 = new Color(0, 0, 0, 1);
@@ -54,19 +57,21 @@ public class ColorChanger_Jann : MonoBehaviour
 
         colorSwapTex.Apply();
 
+        m_swapMaterial.SetTexture("_SwapTex", colorSwapTex);
+        
         foreach (SpriteRenderer spriteRenderer in m_spriteRenderers)
         {
-            spriteRenderer.material.SetTexture("_SwapTex", colorSwapTex);
+            spriteRenderer.material = m_swapMaterial;
         }
         
         foreach (TilemapRenderer tilemapRenderer in m_tilemapRenderers)
         {
-            tilemapRenderer.material.SetTexture("_SwapTex", colorSwapTex);
+            tilemapRenderer.material = m_swapMaterial;
         }
 
         foreach (Image image in m_images)
         {
-            image.material.SetTexture("_SwapTex", colorSwapTex);
+            image.material = m_swapMaterial;
         }
         
         m_spriteColors = new Color[colorSwapTex.width];


### PR DESCRIPTION
… in Unity